### PR TITLE
Improve LogFileGroup error message on hardlink failure

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -135,7 +135,7 @@ public final class LogFileGroup {
         try {
             logFiles = convertToLogFiles(files, componentHardlinksDirectory);
         } catch (IOException e) {
-            logger.atDebug().cause(e).log("Failed to create hardlinks for files. Falling to using regular "
+            logger.atDebug().cause(e).log("Failed to create hardlinks for files. Falling back to using regular "
                     + " files");
             isUsingHardlinks = false;
             logFiles = convertToLogFiles(files);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Clarifying that LogManager is `falling back` to using regular files.

**Why is this change necessary:**
The log message does not make it clear what has happened.

**How was this change tested:**
It's not

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
